### PR TITLE
Improve template import robustness and progress

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Discord Template URL (e.g. https://discord.new/AbCdEfGhIjK)
+# You can paste the full URL or just the code at the end.
+DISCORD_TEMPLATE_URL=
+
+# Your Revolt Bot Token
+# Get this from Settings -> My Bots -> Create Bot -> Copy Token
+REVOLT_BOT_TOKEN=
+
+# The ID of the Revolt Server you are importing into
+# Enable Developer Mode in Revolt Settings to copy this (Right click server name -> Copy ID)
+REVOLT_SERVER_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 venv
 demo_template.json
+*.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,48 @@
-# Discord to Revolt
+# Discord to Revolt Migrator
 
-This script creates a Revolt server using Discord template. It has issues with permissions not synced 
-because permissions in Revolt and Discord work a bit different. Additional manual setting might be necessary.
+A Python tool to migrate a Discord Server Template to a Revolt/Stoat Server. It supports "Smart Matching" to reuse existing channels, preventing duplication and preserving your new server structure.
+
+## 🌟 Features
+* **Smart Mapping**: Automatically detects existing channels (even if names have different emojis or capitalization) and links them instead of creating duplicates.
+* **Fuzzy Matching**: Matches `⚙️Channel⚙️` (Discord) to `⚙️Channel⚙️` (Revolt/Stoat).
+* **Role Migration**: Imports roles, colors, and permissions.
+* **Category Support**: Creates categories and sorts channels into them.
+* **Permission Overwrites**: Applies complex channel permissions (deny/allow rules).
+* **Limit Handling**: Detects the Revolt 200-channel limit and gracefully skips extras.
+* **.env Support**: Load credentials from a file for easy re-running.
+
+## 🛠️ Prerequisites
+* Python 3.10 or higher
+* A Revolt/Stoat Account and Server
+* A Revolt/Stoat Bot (Create this from Settings -> My Bots -> Create Bot)
+
+## 📦 Installation
+
+1.  Clone the repository or download the files.
+2.  Install dependencies:
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## ⚙️ Configuration
+
+1.  Rename `.env.example` to `.env`.
+2.  Fill in the required fields:
+
+    ```ini
+    # Discord Template URL (e.g. [https://discord.new/AbCdEfGhIjK](https://discord.new/AbCdEfGhIjK))
+    DISCORD_TEMPLATE_URL=[https://discord.new/YOUR_CODE_HERE](https://discord.new/YOUR_CODE_HERE)
+
+    # Your Revolt Bot Token
+    REVOLT_BOT_TOKEN=your_bot_token_here
+
+    # The ID of the Revolt Server you are importing into
+    REVOLT_SERVER_ID=your_server_id_here
+    ```
+
+## 🚀 Usage
+
+Run the script:
+
+```bash
+python main.py

--- a/main.py
+++ b/main.py
@@ -1,25 +1,113 @@
-import pyvolt
 import json
 import asyncio
+import time
+from collections import defaultdict, deque
 import requests
+import stoat as pyvolt
+from pathlib import Path
 
 TEMPLATE_IMPORT_STEPS = 5
+PROGRESS_FILE = "import_progress.json"
 
-"""
-	Key    : ID in Discord template
-	Value  : ID in Revolt API
+IDs = {"roles": {}, "channels": {}}
+cache = {"roles": {}, "channels": {}}
 
-	Example: IDs.roles[discordRoleID] == revoltRoleID
-"""
-IDs = {
-	"roles": {},
-	"channels": {}
-}
+# Helper class to handle channels when the library fails
+class RawChannel:
+    def __init__(self, data):
+        self.id = data["_id"]
+        self.name = data.get("name", "Unknown")
+        self.type = data.get("channel_type", "Text")
+        # Store raw data for debugging
+        self._raw = data
 
-cache = {
-	"roles": {},
-	"channels": {}
-}
+    def __repr__(self):
+        return f"<RawChannel id={self.id} name={self.name}>"
+
+
+# ─────────────────────────────────────────────────────────────
+# Revolt API helpers (for when the client library is missing data)
+# ─────────────────────────────────────────────────────────────
+def revolt_api_json(method: str, url: str, headers: dict, payload: dict | None = None, timeout: int = 30):
+    """HTTP helper with basic retry + 429 handling."""
+    for attempt in range(6):
+        resp = requests.request(method, url, headers=headers, json=payload, timeout=timeout)
+        # Handle rate limit
+        if resp.status_code == 429:
+            try:
+                data = resp.json()
+                retry_after = float(data.get("retry_after", 1.0))
+            except Exception:
+                retry_after = 1.0
+            time.sleep(max(0.25, retry_after))
+            continue
+        # Retry transient errors
+        if resp.status_code >= 500 and attempt < 5:
+            time.sleep(0.5 * (attempt + 1))
+            continue
+        if resp.status_code >= 400:
+            raise RuntimeError(f"{method} {url} -> {resp.status_code}: {resp.text}")
+        try:
+            return resp.json()
+        except Exception:
+            return resp.text
+
+def _norm_name(name: str) -> str:
+    return (name or "").casefold().strip()
+
+def _revolt_channel_kind(ch) -> str:
+    """Best-effort mapping of Revolt channel object -> 'text' | 'voice' | 'unknown'."""
+    # RawChannel stores a string in .type
+    t = getattr(ch, "type", None)
+    if isinstance(t, str):
+        tl = t.lower()
+        if "voice" in tl:
+            return "voice"
+        if "text" in tl:
+            return "text"
+    # Library objects may use ChannelType enum
+    try:
+        if t == pyvolt.ChannelType.voice:
+            return "voice"
+        if t == pyvolt.ChannelType.text:
+            return "text"
+    except Exception:
+        pass
+    # Fallback using raw payload if present
+    raw = getattr(ch, "_raw", None)
+    if isinstance(raw, dict):
+        ct = (raw.get("channel_type") or raw.get("type") or "").lower()
+        if "voice" in ct:
+            return "voice"
+        if "text" in ct:
+            return "text"
+    return "unknown"
+
+def build_existing_queues(current_channels):
+    """Build lookup structures that preserve duplicates (Discord templates can have duplicate names)."""
+    by_key = defaultdict(deque)   # (norm_name, kind) -> deque[channel]
+    by_name = defaultdict(deque)  # norm_name -> deque[channel]
+    for ch in current_channels:
+        n = _norm_name(getattr(ch, "name", ""))
+        k = _revolt_channel_kind(ch)
+        by_key[(n, k)].append(ch)
+        by_name[n].append(ch)
+    return by_key, by_name
+
+def save_progress():
+    """Save current progress to file"""
+    with open(PROGRESS_FILE, 'w') as f:
+        json.dump(IDs, f, indent=2)
+    
+def load_progress():
+    """Load progress from file if it exists"""
+    if Path(PROGRESS_FILE).exists():
+        with open(PROGRESS_FILE, 'r') as f:
+            loaded = json.load(f)
+            IDs["roles"] = loaded.get("roles", {})
+            IDs["channels"] = loaded.get("channels", {})
+        return True
+    return False
 
 def d2r(type, id):
     return cache[type][IDs[type][id]]
@@ -28,269 +116,510 @@ def step(current, total=None, text="Something is wrong"):
     print(("\t" if total else ""), "[", current, "/", total or TEMPLATE_IMPORT_STEPS, "] ", text, sep='')
 
 def convert_permission(permissions: int):
-    """
-| Name                                   | Discord | Revolt  |
-| CREATE_INSTANT_INVITE                  | 1 << 0  | 1 << 25 |
-| KICK_MEMBERS                           | 1 << 1  | 1 << 6  |
-| BAN_MEMBERS                            | 1 << 2  | 1 << 7  |
-| ADMINISTRATOR                          | 1 << 3  |         |
-| MANAGE_CHANNELS                        | 1 << 4  | 1 << 0  |
-| MANAGE_GUILD                           | 1 << 5  | 1 << 1  |
-| ADD_REACTIONS                          | 1 << 6  | 1 << 29 |
-| VIEW_AUDIT_LOG                         | 1 << 7  |         |
-| PRIORITY_SPEAKER                       | 1 << 8  |         |
-| STREAM                                 | 1 << 9  |         |
-| VIEW_CHANNEL                           | 1 << 10 | 1 << 20 |
-| SEND_MESSAGES                          | 1 << 11 | 1 << 22 |
-| SEND_TTS_MESSAGES                      | 1 << 12 |         |
-| MANAGE_MESSAGES                        | 1 << 13 | 1 << 23 |
-| EMBED_LINKS                            | 1 << 14 | 1 << 26 |
-| ATTACH_FILES                           | 1 << 15 | 1 << 27 |
-| READ_MESSAGE_HISTORY                   | 1 << 16 | 1 << 21 |
-| MENTION_EVERYONE                       | 1 << 17 |         |
-| USE_EXTERNAL_EMOJIS                    | 1 << 18 |         |
-| VIEW_GUILD_INSIGHTS                    | 1 << 19 |         |
-| CONNECT                                | 1 << 20 | 1 << 30 |
-| SPEAK                                  | 1 << 21 | 1 << 31 |
-| MUTE_MEMBERS                           | 1 << 22 | 1 << 33 |
-| DEAFEN_MEMBERS                         | 1 << 23 | 1 << 34 |
-| MOVE_MEMBERS                           | 1 << 24 | 1 << 35 |
-| USE_VAD                                | 1 << 25 |         |
-| CHANGE_NICKNAME                        | 1 << 26 | 1 << 10 |
-| MANAGE_NICKNAMES                       | 1 << 27 | 1 << 11 |
-| MANAGE_ROLES                           | 1 << 28 | 1 << 3  |
-| MANAGE_WEBHOOKS                        | 1 << 29 | 1 << 24 |
-| MANAGE_GUILD_EXPRESSIONS               | 1 << 30 |         |
-| USE_APPLICATION_COMMANDS               | 1 << 31 |         |
-| REQUEST_TO_SPEAK                       | 1 << 32 |         |
-| MANAGE_EVENTS                          | 1 << 33 |         |
-| MANAGE_THREADS                         | 1 << 34 |         |
-| CREATE_PUBLIC_THREADS                  | 1 << 35 |         |
-| CREATE_PRIVATE_THREADS                 | 1 << 36 |         |
-| USE_EXTERNAL_STICKERS                  | 1 << 37 |         |
-| SEND_MESSAGES_IN_THREADS               | 1 << 38 |         |
-| USE_EMBEDDED_ACTIVITIES                | 1 << 39 |         |
-| MODERATE_MEMBERS                       | 1 << 40 | 1 << 8  |
-| VIEW_CREATOR_MONETIZATION_ANALYTICS    | 1 << 41 |         |
-| USE_SOUNDBOARD                         | 1 << 42 |         |
-| CREATE_GUILD_EXPRESSIONS               | 1 << 43 | 1 << 4  |
-| CREATE_EVENTS                          | 1 << 44 |         |
-| USE_EXTERNAL_SOUNDS                    | 1 << 45 |         |
-| SEND_VOICE_MESSAGES                    | 1 << 46 |         |
-| SEND_POLLS                             | 1 << 49 |         |
-| USE_EXTERNAL_APPS                      | 1 << 50 |         |
-
-| ManagePermissions                      |         | 1 << 2  |
-| AssignRoles                            |         | 1 << 9  |
-| ChangeAvatar                           |         | 1 << 12 |
-| RemoveAvatars                          |         | 1 << 13 |
-| Masquerade                             |         | 1 << 28 |
-    """
-
-    d2r = {
-        43: 4,
-        40: 8,
-        29: 24,
-        28: 3,
-        26: 10,
-        27: 11,
-        0 : 25,
-        1 : 6,
-        2 : 7,
-        4 : 0,
-        5 : 1,
-        6 : 29,
-        10: 20,
-        11: 22,
-        13: 23,
-        14: 26,
-        15: 27,
-        16: 21,
-        20: 30,
-        21: 31,
-        23: 34,
-        22: 33,
-        24: 35,
+    d2r_map = {
+        43:4, 40:8, 29:24, 28:3, 26:10, 27:11, 0:25, 1:6, 2:7, 4:0, 5:1,
+        6:29,10:20,11:22,13:23,14:26,15:27,16:21,20:30,21:31,23:34,22:33,24:35
     }
-    
+
     out = 0
-    max_byte = max([item for pair in d2r.items() for item in pair]) +1
-
-    if type(permissions) == str: permissions = int(permissions)
-    
-    for i in d2r:
+    if isinstance(permissions, str):
+        permissions = int(permissions)
+    for i in d2r_map:
         if permissions & (1 << i):
-            out |= 1 << d2r[i]
-
+            out |= 1 << d2r_map[i]
     return pyvolt.Permissions(out)
 
-# print(convert_permission(1 << 50))
-# print(convert_permission(1 << 43), 1 << 4)
-# print(convert_permission((1 << 43) | (1 << 49)), 1 << 4)
-# print(convert_permission((1 << 43) | (1 << 49) | (1 << 21)), (1 << 4) | (1 << 31))
-# print(convert_permission((1 << 43) | (1 << 21)), (1 << 4) | (1 << 31))
-# 
-# exit()
 async def main():
+    # Check for existing progress
+    has_progress = load_progress()
+    if has_progress:
+        print(f"📂 Found previous progress: {len(IDs['channels'])} channels, {len(IDs['roles'])} roles")
+        resume = input("Resume from previous run? (Y/n): ").strip().lower()
+        if resume != 'n':
+            print("✅ Resuming from saved progress...\n")
+        else:
+            IDs["roles"].clear()
+            IDs["channels"].clear()
+            print("🔄 Starting fresh...\n")
+    
+    # 1. Get the Template URL
     template_url = None
     template = None
     while not template:
         template_url = input("Template URL: ").split("/")[-1]
         if template_url == "":
-            template = json.load(open("demo_template.json"))["serialized_source_guild"]
-            break
+            try:
+                template = json.load(open("demo_template.json"))["serialized_source_guild"]
+                break
+            except:
+                print("❌ demo_template.json not found.")
+                continue
+
         try:
-            template = requests.get(f"https://discord.com/api/v9/guilds/templates/{template_url}").json()["serialized_source_guild"]
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                "Accept": "application/json",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Referer": "https://discord.com/",
+                "Origin": "https://discord.com"
+            }
+            
+            resp = requests.get(f"https://discord.com/api/v9/guilds/templates/{template_url}", headers=headers)
+            
+            if resp.status_code != 200:
+                print(f"❌ API Error: {resp.status_code}")
+                print(f"Response: {resp.text[:200]}") 
+                template_url = None
+                continue
+            
+            try:
+                template = resp.json()["serialized_source_guild"]
+            except (json.JSONDecodeError, KeyError) as e:
+                print(f"❌ Failed to parse response: {e}")
+                print(f"Response preview: {resp.text[:200]}")
+                template_url = None
+                continue
+                
         except Exception as error: 
-            print(error)
+            print(f"❌ Error: {error}")
             template_url = None
             template = None
 
-    print(f"""A new server called "{template["name"]}" will be created.
-{len(template["channels"])} channels and {len(template["roles"])} roles will be added to the server.""")
-    if input("type Y to continue, anything else to cancel: ").lower()[0] != "y": return
+    print(f"""
+    Ready to import template: "{template['name']}"
+    {len(template['channels'])} channels and {len(template['roles'])} roles will be imported.
+    """)
     
-    client = None
-    server = None
-    while not server:
-        client = pyvolt.Client(token=input("Revolt token: "), bot=False)
+    # 2. Get Target Server Info
+    target_server_id = input("Target Revolt Server ID: ")
+
+    # 3. Initialize Client with proper async context manager
+    bot_token = input("Revolt Bot Token: ")
+    
+    async with pyvolt.Client(token=bot_token, bot=True) as client:
         try:
-            server = await client.create_server(
-                name = template["name"],
-                description = template["description"]
-            )
-        except Exception as error: 
-            print(error)
-            client = None
+            print(f"Fetching server {target_server_id}...")
+            server = await client.fetch_server(target_server_id)
+            print(f"✅ Connected to server: {server.name}")
+        except Exception as error:
+            print(f"❌ Error fetching server: {error}")
+            print("Make sure the Bot is in the server and the ID is correct.")
+            return
 
-    step(1, text="Delete default channels")
-
-    deleted = 0
-    total = len(server.channels)
-    for channel in server.channels:
-        step(deleted+1, total, channel.name)
-        await channel.close()
-        deleted += 1
-
-
-    step(2, text="Create channels")
-
-    # 0 - Text channel
-    # 2 - Voice channel
-    # 4 - Category
-
-    channels = template["channels"]
-
-    # Get only text channels
-    # Convert forums to text channels
-    textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
-    voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
-    categories = list(filter(lambda channel: channel["type"] == 4, channels))
-
-    total = len(textChannels) + len(voiceChannels)
-    created = 0
-    for channel in textChannels + voiceChannels:
-        step(created + 1, total, channel["name"])
+        # ═══════════════════════════════════════════════════════
+        #     CRITICAL: FETCH ALL EXISTING CHANNELS (ROBUST)
+        # ═══════════════════════════════════════════════════════
+        print("\n🔍 Scanning server for existing channels...")
         
-        rChannel = await server.create_channel(
-            name = channel["name"],
-            description = channel["topic"], 
-            nsfw = channel["nsfw"],
-            type = (
-                pyvolt.ChannelType.voice 
-                if channel["type"] == 2 else 
-                pyvolt.ChannelType.text
-            )
-        )
+        current_channels = []
+        
+        # Method 1: Try standard library methods
+        try:
+            current_channels = await server.fetch_channels()
+        except:
+            pass
+            
+        if not current_channels and hasattr(server, 'channels'):
+            current_channels = list(server.channels)
+            
+        if not current_channels and hasattr(server, '_channels'):
+            current_channels = list(server._channels.values())
 
-        IDs["channels"][channel["id"]] = rChannel.id
-        cache["channels"][rChannel.id] = rChannel
-        created += 1
+        # Method 2: DIRECT API FALLBACK (If library fails)
+        if not current_channels:
+            print("   ⚠️ Library failed to list channels. Attempting direct API fetch...")
+            try:
+                # Revolt does NOT provide GET /servers/{id}/channels.
+                # Instead: GET /servers/{id} and then resolve its `channels` IDs.
+                api_headers = {"x-bot-token": bot_token}
 
+                server_data = revolt_api_json(
+                    "GET",
+                    f"https://api.revolt.chat/servers/{target_server_id}",
+                    headers=api_headers,
+                )
 
-    step(3, text="Setup categories")
+                channel_ids = server_data.get("channels", []) if isinstance(server_data, dict) else []
 
-    await server.edit(
-        categories=[
-            pyvolt.Category(
-                id = str(category["id"]),
-                title = category["name"],
-                channels = [
+                for cid in channel_ids:
+                    try:
+                        ch_data = revolt_api_json(
+                            "GET",
+                            f"https://api.revolt.chat/channels/{cid}",
+                            headers=api_headers,
+                        )
+                        if isinstance(ch_data, dict) and ch_data.get("_id"):
+                            current_channels.append(RawChannel(ch_data))
+                    except Exception:
+                        # Ignore individual channel failures; keep scanning
+                        pass
+
+                print(f"   ✅ Direct API found {len(current_channels)} channels")
+            except Exception as e:
+                print(f"   ❌ Direct API error: {e}")
+
+        print(f"✅ Found {len(current_channels)} existing channels on Revolt server\n")
+        
+        # Create a simple dict mapping channel name to channel object
+        existing_by_name = {ch.name: ch for ch in current_channels}
+
+        # Keep duplicates for safe matching (templates can contain same names)
+        server_channel_ids = {ch.id for ch in current_channels}
+        existing_by_key, existing_by_name_queue = build_existing_queues(current_channels)
+
+        # Keep duplicates for safe matching (templates can contain same names)
+        server_channel_ids = {ch.id for ch in current_channels}
+        existing_by_key, existing_by_name_queue = build_existing_queues(current_channels)
+        
+        # Ask user for import mode
+        print("╔════════════════════════════════════════════════════════╗")
+        print("║                    IMPORT MODES                        ║")
+        print("╚════════════════════════════════════════════════════════╝")
+        print("1. 🚀 CATEGORIES ONLY - Fast! Just organize existing channels")
+        print("2. 🔄 SMART MODE     - Reuse existing channels, create missing ones")
+        print("3. 🗑️  CLEAN SLATE   - Delete everything and recreate from template")
+        mode = input("\nChoose mode (1/2/3): ").strip()
+
+        if mode == "1":
+            # ═══════════════════════════════════════════════════════
+            #           CATEGORIES ONLY MODE
+            # ═══════════════════════════════════════════════════════
+            print("\n🚀 CATEGORIES ONLY MODE\n")
+            
+            channels = template["channels"]
+            textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
+            voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
+            categories = list(filter(lambda channel: channel["type"] == 4, channels))
+
+            step(1, 2, "Mapping existing channels to template")
+
+            mapped = 0
+            not_found = 0
+            used_revolt_ids = set()
+
+            # Go through each channel in the template.
+            # IMPORTANT: do NOT match solely by name -> templates can have duplicate channel names.
+            for channel in textChannels + voiceChannels:
+                channel_name = channel["name"]
+                discord_id = channel["id"]
+                desired_kind = "voice" if channel.get("type") == 2 else "text"
+
+                # 1) Keep saved mapping if it's still valid and not already used
+                revolt_id = IDs["channels"].get(discord_id)
+                if revolt_id and revolt_id in server_channel_ids and revolt_id not in used_revolt_ids:
+                    used_revolt_ids.add(revolt_id)
+                    mapped += 1
+                    continue
+
+                # 2) Match by (name + kind) preserving duplicates
+                key = (_norm_name(channel_name), desired_kind)
+                q = existing_by_key.get(key)
+                chosen = None
+                if q:
+                    while q and q[0].id in used_revolt_ids:
+                        q.popleft()
+                    if q:
+                        chosen = q.popleft()
+
+                # 3) Fallback: match by name only (still unique)
+                if chosen is None:
+                    qn = existing_by_name_queue.get(_norm_name(channel_name))
+                    if qn:
+                        while qn and qn[0].id in used_revolt_ids:
+                            qn.popleft()
+                        if qn:
+                            chosen = qn.popleft()
+
+                if chosen:
+                    IDs["channels"][discord_id] = chosen.id
+                    used_revolt_ids.add(chosen.id)
+                    mapped += 1
+                else:
+                    not_found += 1
+
+            print(f"    ✅ Mapped {mapped} channels")
+            save_progress()
+
+            step(2, 2, "Creating categories")
+            
+            # Build category structure (validated + de-duplicated)
+            category_list = []
+            assigned_in_categories = set()
+
+            for category in categories:
+                cat_channel_ids = []
+
+                # Keep template order: iterate in the same order as the template channels list
+                for ch in textChannels + voiceChannels:
+                    if ch.get("parent_id") != category["id"]:
+                        continue
+                    discord_id = ch["id"]
+                    revolt_id = IDs["channels"].get(discord_id)
+                    if not revolt_id:
+                        continue
+                    # Validate: channel must actually exist in this Revolt server
+                    if revolt_id not in server_channel_ids:
+                        continue
+                    # Revolt category structure expects each channel to appear at most once overall
+                    if revolt_id in assigned_in_categories:
+                        continue
+                    assigned_in_categories.add(revolt_id)
+                    cat_channel_ids.append(revolt_id)
+
+                if cat_channel_ids:
+                    category_list.append(
+                        pyvolt.Category(
+                            id=str(category["id"]),
+                            title=(category["name"][:32]),
+                            channels=cat_channel_ids
+                        )
+                    )
+
+            if category_list:
+                print(f"\n    📦 Applying {len(category_list)} categories...")
+                try:
+                    await server.edit(categories=category_list)
+                    print(f"    ✅ Categories created successfully!")
+                except Exception as e:
+                    # Fallback: direct PATCH to the server edit endpoint
+                    print(f"    ⚠️ server.edit failed ({e}). Trying direct PATCH...")
+                    try:
+                        api_headers = {"x-bot-token": bot_token, "Content-Type": "application/json"}
+                        payload = {
+                            "categories": [
+                                {"id": c.id, "title": c.title, "channels": list(c.channels)}
+                                for c in category_list
+                            ]
+                        }
+                        resp = requests.patch(
+                            f"https://api.revolt.chat/servers/{target_server_id}",
+                            headers=api_headers,
+                            json=payload,
+                            timeout=30,
+                        )
+                        if resp.status_code == 200:
+                            print("    ✅ Categories updated successfully via direct PATCH!")
+                        else:
+                            print(f"    ❌ Direct PATCH failed: {resp.status_code} - {resp.text}")
+                    except Exception as e2:
+                        print(f"    ❌ Direct PATCH exception: {e2}")
+            else:
+                print("    ⚠️  No categories created (did you map any channels?)")
+
+        elif mode == "3":
+            # ═══════════════════════════════════════════════════════
+            #                CLEAN SLATE MODE
+            # ═══════════════════════════════════════════════════════
+            step(1, text="Deleting all existing channels")
+            deleted = 0
+            total = len(current_channels)
+            for channel in current_channels:
+                step(deleted+1, total, channel.name)
+                try:
+                    # If it's a RawChannel, we need to fetch the real one or use ID
+                    if isinstance(channel, RawChannel):
+                        # Try to use requests delete for raw channel
+                        requests.delete(
+                            f"https://api.revolt.chat/channels/{channel.id}",
+                            headers={"x-bot-token": bot_token}
+                        )
+                    else:
+                        await channel.close()
+                except Exception as e:
+                    print(f"    ⚠️  Failed to delete {channel.name}")
+                deleted += 1
+            
+            current_channels = []
+            existing_by_name = {}
+            IDs["channels"].clear()
+            IDs["roles"].clear()
+            save_progress()
+            mode = "2"  # Continue with smart mode
+
+        if mode == "2" or mode == "3":
+            # ═══════════════════════════════════════════════════════
+            #                   SMART MODE
+            # ═══════════════════════════════════════════════════════
+            print("\n🔄 SMART MODE - Reusing existing channels\n")
+
+            channels = template["channels"]
+            textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
+            voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
+            categories = list(filter(lambda channel: channel["type"] == 4, channels))
+
+            step(2, text="Processing channels")
+            
+            total = len(textChannels) + len(voiceChannels)
+            created = 0
+            reused = 0
+            skipped = 0
+            
+            for i, channel in enumerate(textChannels + voiceChannels):
+                channel_name = channel["name"]
+                discord_id = channel["id"]
+                
+                # 1. Already processed?
+                if discord_id in IDs["channels"]:
+                    step(i+1, total, f"{channel_name} ✓ already done")
+                    reused += 1
+                    continue
+                
+                # 2. Exists on server?
+                if channel_name in existing_by_name:
+                    step(i+1, total, f"{channel_name} ✓ exists, reusing")
+                    rChannel = existing_by_name[channel_name]
+                    IDs["channels"][discord_id] = rChannel.id
+                    # If it's a real object, cache it
+                    if not isinstance(rChannel, RawChannel):
+                        cache["channels"][rChannel.id] = rChannel
+                    reused += 1
+                    save_progress()
+                    continue
+                
+                # 3. Create it
+                try:
+                    step(i+1, total, f"{channel_name} → creating...")
+                    rChannel = await server.create_channel(
+                        name = channel_name,
+                        description = channel.get("topic", ""), 
+                        nsfw = channel.get("nsfw", False),
+                        type = (
+                            pyvolt.ChannelType.voice 
+                            if channel["type"] == 2 else 
+                            pyvolt.ChannelType.text
+                        )
+                    )
+                    IDs["channels"][discord_id] = rChannel.id
+                    cache["channels"][rChannel.id] = rChannel
+                    existing_by_name[channel_name] = rChannel
+                    created += 1
+                    save_progress()
+                    
+                except pyvolt.HTTPException as e:
+                    if "TooManyChannels" in str(e):
+                        step(i+1, total, f"{channel_name} ⚠️ LIMIT REACHED")
+                        skipped += 1
+                    else:
+                        print(f"\n    ❌ Error creating {channel_name}: {e}")
+                        skipped += 1
+                except Exception as e:
+                    print(f"\n    ❌ Unexpected error: {e}")
+                    skipped += 1
+
+            print(f"\n  📊 Summary: Created {created} | Reused {reused} | Skipped {skipped}")
+
+            step(3, text="Setting up categories")
+
+            category_list = []
+            for category in categories:
+                category_channels = [
                     IDs["channels"][channel["id"]]
                     for channel in textChannels + voiceChannels
-                    if channel["parent_id"] == category["id"] 
+                    if channel.get("parent_id") == category["id"] and channel["id"] in IDs["channels"]
                 ]
-            )
+                
+                if category_channels:
+                    category_list.append(
+                        pyvolt.Category(
+                            id = str(category["id"]),
+                            title = category["name"],
+                            channels = category_channels
+                        )
+                    )
 
-            for category in categories
-        ]
-    )
+            if category_list:
+                await server.edit(categories=category_list)
+                print(f"  ✅ Created {len(category_list)} categories")
 
+            step(4, text="Creating/updating roles")
+            
+            # FIX: Find the @everyone role ID safely
+            template_everyone_id = None
+            for r in template["roles"]:
+                if r["name"] == "@everyone":
+                    template_everyone_id = r["id"]
+                    break
+            if template_everyone_id is None and "id" in template:
+                template_everyone_id = template["id"]
 
-    step(4, text="Create and setup roles")
-    
-    total = len(template["roles"])
-    created = 0
-    for role in template["roles"]:
-        step(created + 1, total, role["name"])
-        if role["id"] == 0:
-            await server.set_default_permissions(
-                convert_permission(role["permissions"])
-            )
-            created += 1
-            continue
-        
-        rRole = await server.create_role(
-            name = role["name"],
-            rank = role["id"]
-        )
-        
-        IDs["roles"][role["id"]] = rRole.id
-        cache["roles"][rRole.id] = rRole
-        
-        await rRole.edit(
-            color = "#" + hex(role["color"])[2:],
-            hoist = role["hoist"]
-        )
-        await server.set_role_permissions(
-            rRole,
-            allow = convert_permission(
-                role["permissions"]
-            ),
-            deny = pyvolt.Permissions(0)
-        )
-        created += 1
+            try:
+                existing_roles = await server.fetch_roles()
+            except:
+                existing_roles = []
+            
+            existing_roles_by_name = {role.name: role for role in existing_roles}
+            
+            total_roles = len(template["roles"])
+            for i, role in enumerate(template["roles"]):
+                role_name = role["name"]
+                discord_id = role["id"]
+                step(i+1, total_roles, role_name)
+                
+                if discord_id == template_everyone_id:
+                    await server.set_default_permissions(
+                        convert_permission(role["permissions"])
+                    )
+                    continue
+                
+                if discord_id in IDs["roles"]:
+                    rRole = next((r for r in existing_roles if r.id == IDs["roles"][discord_id]), None)
+                    if not rRole and role_name in existing_roles_by_name:
+                        rRole = existing_roles_by_name[role_name]
+                elif role_name in existing_roles_by_name:
+                    rRole = existing_roles_by_name[role_name]
+                else:
+                    rRole = await server.create_role(name=role_name, rank=role.get("position", 1))
+                
+                if rRole:
+                    IDs["roles"][discord_id] = rRole.id
+                    cache["roles"][rRole.id] = rRole
+                    
+                    color_hex = "#" + hex(role.get("color", 0))[2:].zfill(6)
+                    await rRole.edit(color=color_hex, hoist=role.get("hoist", False))
+                    await server.set_role_permissions(
+                        rRole,
+                        allow=convert_permission(role["permissions"]),
+                        deny=pyvolt.Permissions(0)
+                    )
+                    save_progress()
 
+            step(5, text="Setting channel permissions")
 
-    step(5, text="Set permissions for channels")
+            channels_with_perms = [
+                ch for ch in textChannels + voiceChannels
+                if ch.get("permission_overwrites") and ch["id"] in IDs["channels"]
+            ]
+            
+            for i, channel in enumerate(channels_with_perms):
+                step(i+1, len(channels_with_perms), channel["name"])
+                revolt_id = IDs["channels"][channel["id"]]
+                
+                # We need a REAL object to set permissions
+                rChannel = cache["channels"].get(revolt_id)
+                
+                # If it's not in cache or is a RawChannel, we must fetch the real object
+                if not rChannel or isinstance(rChannel, RawChannel):
+                    try:
+                        rChannel = await client.fetch_channel(revolt_id)
+                        cache["channels"][revolt_id] = rChannel
+                    except:
+                        print(f"    ⚠️ Could not fetch channel {channel['name']} for permissions")
+                        continue
 
-    channels_to_handle = [
-        channel
-        for channel in textChannels + voiceChannels
-        if channel["permission_overwrites"]
-    ]
-    total = len(channels_to_handle)
-    handled = 0
-    for channel in channels_to_handle:
-        step(handled + 1, total, channel["name"])
-        rChannel = d2r("channels", channel["id"])
+                for overwrite in channel["permission_overwrites"]:
+                    ow = {
+                        "allow": convert_permission(overwrite.get("allow", 0)),
+                        "deny": convert_permission(overwrite.get("deny", 0)),
+                    }
 
-        for overwrite in channel["permission_overwrites"]:
-            ow = {
-                "allow": convert_permission(overwrite["allow"]),
-                "deny": convert_permission(overwrite["deny"]),
-            }
+                    if overwrite["id"] == template_everyone_id:
+                        await rChannel.set_default_permissions(pyvolt.PermissionOverride(**ow))
+                    elif overwrite["id"] in IDs["roles"]:
+                        await rChannel.set_role_permissions(d2r("roles", overwrite["id"]), **ow)
+            
+            print("\n✅ Import complete!")
+            if skipped > 0:
+                print(f"\n⚠️  {skipped} channels skipped (200 channel limit reached)")
 
-            if overwrite["id"] == 0:
-                await rChannel.set_default_permissions(
-                    pyvolt.PermissionOverride(**ow)
-                )
-            else:
-                await rChannel.set_role_permissions(
-                    d2r("roles", overwrite["id"]),
-                    **ow
-                )
-        
-        handled += 1
-
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import json
 import asyncio
 import time
+import random
+import re
 from collections import defaultdict, deque
 import requests
 import stoat as pyvolt
@@ -8,99 +10,104 @@ from pathlib import Path
 
 TEMPLATE_IMPORT_STEPS = 5
 PROGRESS_FILE = "import_progress.json"
+CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 IDs = {"roles": {}, "channels": {}}
 cache = {"roles": {}, "channels": {}}
 
-# Helper class to handle channels when the library fails
+# --- HELPER: Generate Valid Revolt IDs (ULIDs) ---
+def generate_ulid():
+    """Generates a valid ULID (26 chars) for Revolt categories"""
+    t = int(time.time() * 1000)
+    chars = []
+    for _ in range(10):
+        chars.append(CROCKFORD_BASE32[t & 31])
+        t >>= 5
+    chars.reverse()
+    for _ in range(16):
+        chars.append(random.choice(CROCKFORD_BASE32))
+    return "".join(chars)
+
 class RawChannel:
     def __init__(self, data):
         self.id = data["_id"]
         self.name = data.get("name", "Unknown")
         self.type = data.get("channel_type", "Text")
-        # Store raw data for debugging
         self._raw = data
-
     def __repr__(self):
         return f"<RawChannel id={self.id} name={self.name}>"
 
-
-# ─────────────────────────────────────────────────────────────
-# Revolt API helpers (for when the client library is missing data)
-# ─────────────────────────────────────────────────────────────
-def revolt_api_json(method: str, url: str, headers: dict, payload: dict | None = None, timeout: int = 30):
-    """HTTP helper with basic retry + 429 handling."""
+def revolt_api_json(method: str, url: str, headers: dict, payload: dict | None = None, params: dict | None = None, timeout: int = 30):
+    """HTTP helper with retry + 429 handling + params support."""
     for attempt in range(6):
-        resp = requests.request(method, url, headers=headers, json=payload, timeout=timeout)
-        # Handle rate limit
-        if resp.status_code == 429:
-            try:
-                data = resp.json()
-                retry_after = float(data.get("retry_after", 1.0))
-            except Exception:
-                retry_after = 1.0
-            time.sleep(max(0.25, retry_after))
-            continue
-        # Retry transient errors
-        if resp.status_code >= 500 and attempt < 5:
-            time.sleep(0.5 * (attempt + 1))
-            continue
-        if resp.status_code >= 400:
-            raise RuntimeError(f"{method} {url} -> {resp.status_code}: {resp.text}")
         try:
+            resp = requests.request(method, url, headers=headers, json=payload, params=params, timeout=timeout)
+            if resp.status_code == 429:
+                try:
+                    data = resp.json()
+                    retry_after = float(data.get("retry_after", 2.0))
+                except:
+                    retry_after = 2.0
+                print(f"    ⏳ Rate limit hit, waiting {retry_after}s...")
+                time.sleep(retry_after + 0.5)
+                continue
+            if resp.status_code >= 500 and attempt < 5:
+                time.sleep(1)
+                continue
+            if resp.status_code >= 400:
+                return {"error": resp.text, "status": resp.status_code}
             return resp.json()
-        except Exception:
-            return resp.text
+        except Exception as e:
+            if attempt == 5:
+                return {"error": str(e), "status": 0}
+            time.sleep(1)
 
 def _norm_name(name: str) -> str:
+    """Basic normalization (lowercase, stripped)."""
     return (name or "").casefold().strip()
 
+def _strip_name(name: str) -> str:
+    """Aggressive normalization: removes emojis/symbols to match 'Factorio' with '⚙️Factorio⚙️'."""
+    return re.sub(r'[\W_]+', '', name).lower()
+
 def _revolt_channel_kind(ch) -> str:
-    """Best-effort mapping of Revolt channel object -> 'text' | 'voice' | 'unknown'."""
-    # RawChannel stores a string in .type
     t = getattr(ch, "type", None)
     if isinstance(t, str):
-        tl = t.lower()
-        if "voice" in tl:
-            return "voice"
-        if "text" in tl:
-            return "text"
-    # Library objects may use ChannelType enum
+        if "voice" in t.lower(): return "voice"
+        if "text" in t.lower(): return "text"
     try:
-        if t == pyvolt.ChannelType.voice:
-            return "voice"
-        if t == pyvolt.ChannelType.text:
-            return "text"
-    except Exception:
-        pass
-    # Fallback using raw payload if present
+        if t == pyvolt.ChannelType.voice: return "voice"
+        if t == pyvolt.ChannelType.text: return "text"
+    except: pass
     raw = getattr(ch, "_raw", None)
     if isinstance(raw, dict):
         ct = (raw.get("channel_type") or raw.get("type") or "").lower()
-        if "voice" in ct:
-            return "voice"
-        if "text" in ct:
-            return "text"
+        if "voice" in ct: return "voice"
+        if "text" in ct: return "text"
     return "unknown"
 
 def build_existing_queues(current_channels):
-    """Build lookup structures that preserve duplicates (Discord templates can have duplicate names)."""
-    by_key = defaultdict(deque)   # (norm_name, kind) -> deque[channel]
-    by_name = defaultdict(deque)  # norm_name -> deque[channel]
+    by_key = defaultdict(deque)      # (norm_name, kind)
+    by_name = defaultdict(deque)     # norm_name
+    by_stripped = defaultdict(deque) # stripped_name (fuzzy match)
+    
     for ch in current_channels:
-        n = _norm_name(getattr(ch, "name", ""))
+        name_raw = getattr(ch, "name", "")
+        n = _norm_name(name_raw)
+        s = _strip_name(name_raw)
         k = _revolt_channel_kind(ch)
+        
         by_key[(n, k)].append(ch)
         by_name[n].append(ch)
-    return by_key, by_name
+        if s: by_stripped[s].append(ch)
+        
+    return by_key, by_name, by_stripped
 
 def save_progress():
-    """Save current progress to file"""
     with open(PROGRESS_FILE, 'w') as f:
         json.dump(IDs, f, indent=2)
     
 def load_progress():
-    """Load progress from file if it exists"""
     if Path(PROGRESS_FILE).exists():
         with open(PROGRESS_FILE, 'r') as f:
             loaded = json.load(f)
@@ -116,21 +123,14 @@ def step(current, total=None, text="Something is wrong"):
     print(("\t" if total else ""), "[", current, "/", total or TEMPLATE_IMPORT_STEPS, "] ", text, sep='')
 
 def convert_permission(permissions: int):
-    d2r_map = {
-        43:4, 40:8, 29:24, 28:3, 26:10, 27:11, 0:25, 1:6, 2:7, 4:0, 5:1,
-        6:29,10:20,11:22,13:23,14:26,15:27,16:21,20:30,21:31,23:34,22:33,24:35
-    }
-
+    d2r_map = {43:4, 40:8, 29:24, 28:3, 26:10, 27:11, 0:25, 1:6, 2:7, 4:0, 5:1, 6:29,10:20,11:22,13:23,14:26,15:27,16:21,20:30,21:31,23:34,22:33,24:35}
     out = 0
-    if isinstance(permissions, str):
-        permissions = int(permissions)
+    if isinstance(permissions, str): permissions = int(permissions)
     for i in d2r_map:
-        if permissions & (1 << i):
-            out |= 1 << d2r_map[i]
+        if permissions & (1 << i): out |= 1 << d2r_map[i]
     return pyvolt.Permissions(out)
 
 async def main():
-    # Check for existing progress
     has_progress = load_progress()
     if has_progress:
         print(f"📂 Found previous progress: {len(IDs['channels'])} channels, {len(IDs['roles'])} roles")
@@ -142,7 +142,6 @@ async def main():
             IDs["channels"].clear()
             print("🔄 Starting fresh...\n")
     
-    # 1. Get the Template URL
     template_url = None
     template = None
     while not template:
@@ -156,30 +155,13 @@ async def main():
                 continue
 
         try:
-            headers = {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                "Accept": "application/json",
-                "Accept-Language": "en-US,en;q=0.9",
-                "Referer": "https://discord.com/",
-                "Origin": "https://discord.com"
-            }
-            
+            headers = {"User-Agent": "Mozilla/5.0", "Accept": "application/json"}
             resp = requests.get(f"https://discord.com/api/v9/guilds/templates/{template_url}", headers=headers)
-            
             if resp.status_code != 200:
                 print(f"❌ API Error: {resp.status_code}")
-                print(f"Response: {resp.text[:200]}") 
                 template_url = None
                 continue
-            
-            try:
-                template = resp.json()["serialized_source_guild"]
-            except (json.JSONDecodeError, KeyError) as e:
-                print(f"❌ Failed to parse response: {e}")
-                print(f"Response preview: {resp.text[:200]}")
-                template_url = None
-                continue
-                
+            template = resp.json()["serialized_source_guild"]
         except Exception as error: 
             print(f"❌ Error: {error}")
             template_url = None
@@ -190,10 +172,7 @@ async def main():
     {len(template['channels'])} channels and {len(template['roles'])} roles will be imported.
     """)
     
-    # 2. Get Target Server Info
     target_server_id = input("Target Revolt Server ID: ")
-
-    # 3. Initialize Client with proper async context manager
     bot_token = input("Revolt Bot Token: ")
     
     async with pyvolt.Client(token=bot_token, bot=True) as client:
@@ -203,76 +182,49 @@ async def main():
             print(f"✅ Connected to server: {server.name}")
         except Exception as error:
             print(f"❌ Error fetching server: {error}")
-            print("Make sure the Bot is in the server and the ID is correct.")
             return
 
-        # ═══════════════════════════════════════════════════════
-        #     CRITICAL: FETCH ALL EXISTING CHANNELS (ROBUST)
-        # ═══════════════════════════════════════════════════════
         print("\n🔍 Scanning server for existing channels...")
-        
         current_channels = []
         
-        # Method 1: Try standard library methods
+        # Optimized Bulk Fetch
         try:
-            current_channels = await server.fetch_channels()
-        except:
-            pass
+            api_headers = {"x-bot-token": bot_token}
+            server_data = revolt_api_json(
+                "GET", 
+                f"https://api.revolt.chat/servers/{target_server_id}", 
+                headers=api_headers,
+                params={"include_channels": "true"}
+            )
             
-        if not current_channels and hasattr(server, 'channels'):
-            current_channels = list(server.channels)
-            
-        if not current_channels and hasattr(server, '_channels'):
-            current_channels = list(server._channels.values())
-
-        # Method 2: DIRECT API FALLBACK (If library fails)
-        if not current_channels:
-            print("   ⚠️ Library failed to list channels. Attempting direct API fetch...")
-            try:
-                # Revolt does NOT provide GET /servers/{id}/channels.
-                # Instead: GET /servers/{id} and then resolve its `channels` IDs.
-                api_headers = {"x-bot-token": bot_token}
-
-                server_data = revolt_api_json(
-                    "GET",
-                    f"https://api.revolt.chat/servers/{target_server_id}",
-                    headers=api_headers,
-                )
-
-                channel_ids = server_data.get("channels", []) if isinstance(server_data, dict) else []
-
-                for cid in channel_ids:
-                    try:
-                        ch_data = revolt_api_json(
-                            "GET",
-                            f"https://api.revolt.chat/channels/{cid}",
-                            headers=api_headers,
-                        )
-                        if isinstance(ch_data, dict) and ch_data.get("_id"):
+            if isinstance(server_data, dict):
+                if "channels" in server_data and isinstance(server_data["channels"], list):
+                    raw_list = server_data["channels"]
+                    if len(raw_list) > 0 and isinstance(raw_list[0], dict):
+                        for ch_data in raw_list:
                             current_channels.append(RawChannel(ch_data))
-                    except Exception:
-                        # Ignore individual channel failures; keep scanning
-                        pass
+                    elif len(raw_list) > 0 and isinstance(raw_list[0], str):
+                        print(f"   ℹ️ API returned IDs only. Fetching {len(raw_list)} channels...")
+                        for cid in raw_list:
+                            ch_data = revolt_api_json("GET", f"https://api.revolt.chat/channels/{cid}", headers=api_headers)
+                            if isinstance(ch_data, dict) and ch_data.get("_id"):
+                                current_channels.append(RawChannel(ch_data))
+        except Exception as e:
+            print(f"   ❌ API error: {e}")
 
-                print(f"   ✅ Direct API found {len(current_channels)} channels")
-            except Exception as e:
-                print(f"   ❌ Direct API error: {e}")
+        # Fallback to library cache
+        if not current_channels:
+             if hasattr(server, 'channels'): current_channels = list(server.channels)
+             elif hasattr(server, '_channels'): current_channels = list(server._channels.values())
 
-        print(f"✅ Found {len(current_channels)} existing channels on Revolt server\n")
+        print(f"✅ Found {len(current_channels)} existing channels on Revolt server")
+        if len(current_channels) >= 190:
+            print("⚠️  WARNING: Server is nearing the 200 channel limit. Fuzzy matching will try to reuse existing channels to avoid errors.")
         
-        # Create a simple dict mapping channel name to channel object
-        existing_by_name = {ch.name: ch for ch in current_channels}
-
-        # Keep duplicates for safe matching (templates can contain same names)
         server_channel_ids = {ch.id for ch in current_channels}
-        existing_by_key, existing_by_name_queue = build_existing_queues(current_channels)
-
-        # Keep duplicates for safe matching (templates can contain same names)
-        server_channel_ids = {ch.id for ch in current_channels}
-        existing_by_key, existing_by_name_queue = build_existing_queues(current_channels)
+        existing_by_key, existing_by_name_queue, existing_by_stripped_queue = build_existing_queues(current_channels)
         
-        # Ask user for import mode
-        print("╔════════════════════════════════════════════════════════╗")
+        print("\n╔════════════════════════════════════════════════════════╗")
         print("║                    IMPORT MODES                        ║")
         print("╚════════════════════════════════════════════════════════╝")
         print("1. 🚀 CATEGORIES ONLY - Fast! Just organize existing channels")
@@ -280,346 +232,213 @@ async def main():
         print("3. 🗑️  CLEAN SLATE   - Delete everything and recreate from template")
         mode = input("\nChoose mode (1/2/3): ").strip()
 
-        if mode == "1":
-            # ═══════════════════════════════════════════════════════
-            #           CATEGORIES ONLY MODE
-            # ═══════════════════════════════════════════════════════
-            print("\n🚀 CATEGORIES ONLY MODE\n")
-            
-            channels = template["channels"]
-            textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
-            voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
-            categories = list(filter(lambda channel: channel["type"] == 4, channels))
+        channels = template["channels"]
+        textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
+        voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
+        categories = list(filter(lambda channel: channel["type"] == 4, channels))
 
-            step(1, 2, "Mapping existing channels to template")
-
-            mapped = 0
-            not_found = 0
-            used_revolt_ids = set()
-
-            # Go through each channel in the template.
-            # IMPORTANT: do NOT match solely by name -> templates can have duplicate channel names.
-            for channel in textChannels + voiceChannels:
-                channel_name = channel["name"]
-                discord_id = channel["id"]
-                desired_kind = "voice" if channel.get("type") == 2 else "text"
-
-                # 1) Keep saved mapping if it's still valid and not already used
-                revolt_id = IDs["channels"].get(discord_id)
-                if revolt_id and revolt_id in server_channel_ids and revolt_id not in used_revolt_ids:
-                    used_revolt_ids.add(revolt_id)
-                    mapped += 1
-                    continue
-
-                # 2) Match by (name + kind) preserving duplicates
-                key = (_norm_name(channel_name), desired_kind)
-                q = existing_by_key.get(key)
-                chosen = None
-                if q:
-                    while q and q[0].id in used_revolt_ids:
-                        q.popleft()
-                    if q:
-                        chosen = q.popleft()
-
-                # 3) Fallback: match by name only (still unique)
-                if chosen is None:
-                    qn = existing_by_name_queue.get(_norm_name(channel_name))
-                    if qn:
-                        while qn and qn[0].id in used_revolt_ids:
-                            qn.popleft()
-                        if qn:
-                            chosen = qn.popleft()
-
-                if chosen:
-                    IDs["channels"][discord_id] = chosen.id
-                    used_revolt_ids.add(chosen.id)
-                    mapped += 1
-                else:
-                    not_found += 1
-
-            print(f"    ✅ Mapped {mapped} channels")
-            save_progress()
-
-            step(2, 2, "Creating categories")
-            
-            # Build category structure (validated + de-duplicated)
-            category_list = []
-            assigned_in_categories = set()
-
-            for category in categories:
-                cat_channel_ids = []
-
-                # Keep template order: iterate in the same order as the template channels list
-                for ch in textChannels + voiceChannels:
-                    if ch.get("parent_id") != category["id"]:
-                        continue
-                    discord_id = ch["id"]
-                    revolt_id = IDs["channels"].get(discord_id)
-                    if not revolt_id:
-                        continue
-                    # Validate: channel must actually exist in this Revolt server
-                    if revolt_id not in server_channel_ids:
-                        continue
-                    # Revolt category structure expects each channel to appear at most once overall
-                    if revolt_id in assigned_in_categories:
-                        continue
-                    assigned_in_categories.add(revolt_id)
-                    cat_channel_ids.append(revolt_id)
-
-                if cat_channel_ids:
-                    category_list.append(
-                        pyvolt.Category(
-                            id=str(category["id"]),
-                            title=(category["name"][:32]),
-                            channels=cat_channel_ids
-                        )
-                    )
-
-            if category_list:
-                print(f"\n    📦 Applying {len(category_list)} categories...")
+        if mode == "3":
+            step(1, text="Deleting channels")
+            for ch in current_channels:
                 try:
-                    await server.edit(categories=category_list)
-                    print(f"    ✅ Categories created successfully!")
-                except Exception as e:
-                    # Fallback: direct PATCH to the server edit endpoint
-                    print(f"    ⚠️ server.edit failed ({e}). Trying direct PATCH...")
-                    try:
-                        api_headers = {"x-bot-token": bot_token, "Content-Type": "application/json"}
-                        payload = {
-                            "categories": [
-                                {"id": c.id, "title": c.title, "channels": list(c.channels)}
-                                for c in category_list
-                            ]
-                        }
-                        resp = requests.patch(
-                            f"https://api.revolt.chat/servers/{target_server_id}",
-                            headers=api_headers,
-                            json=payload,
-                            timeout=30,
-                        )
-                        if resp.status_code == 200:
-                            print("    ✅ Categories updated successfully via direct PATCH!")
-                        else:
-                            print(f"    ❌ Direct PATCH failed: {resp.status_code} - {resp.text}")
-                    except Exception as e2:
-                        print(f"    ❌ Direct PATCH exception: {e2}")
-            else:
-                print("    ⚠️  No categories created (did you map any channels?)")
-
-        elif mode == "3":
-            # ═══════════════════════════════════════════════════════
-            #                CLEAN SLATE MODE
-            # ═══════════════════════════════════════════════════════
-            step(1, text="Deleting all existing channels")
-            deleted = 0
-            total = len(current_channels)
-            for channel in current_channels:
-                step(deleted+1, total, channel.name)
-                try:
-                    # If it's a RawChannel, we need to fetch the real one or use ID
-                    if isinstance(channel, RawChannel):
-                        # Try to use requests delete for raw channel
-                        requests.delete(
-                            f"https://api.revolt.chat/channels/{channel.id}",
-                            headers={"x-bot-token": bot_token}
-                        )
+                    if isinstance(ch, RawChannel):
+                        requests.delete(f"https://api.revolt.chat/channels/{ch.id}", headers={"x-bot-token": bot_token})
                     else:
-                        await channel.close()
-                except Exception as e:
-                    print(f"    ⚠️  Failed to delete {channel.name}")
-                deleted += 1
-            
+                        await ch.close()
+                except: pass
             current_channels = []
-            existing_by_name = {}
+            existing_by_key, existing_by_name_queue, existing_by_stripped_queue = defaultdict(deque), defaultdict(deque), defaultdict(deque)
+            server_channel_ids = set()
             IDs["channels"].clear()
             IDs["roles"].clear()
             save_progress()
-            mode = "2"  # Continue with smart mode
+            mode = "2"
 
-        if mode == "2" or mode == "3":
-            # ═══════════════════════════════════════════════════════
-            #                   SMART MODE
-            # ═══════════════════════════════════════════════════════
-            print("\n🔄 SMART MODE - Reusing existing channels\n")
-
-            channels = template["channels"]
-            textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
-            voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
-            categories = list(filter(lambda channel: channel["type"] == 4, channels))
-
-            step(2, text="Processing channels")
+        if mode == "1" or mode == "2":
+            mode_name = "SMART MODE" if mode == "2" else "CATEGORIES ONLY"
+            print(f"\n🔄 {mode_name}\n")
             
+            step(2, text="Processing channels")
             total = len(textChannels) + len(voiceChannels)
             created = 0
             reused = 0
             skipped = 0
+            used_revolt_ids = set()
             
             for i, channel in enumerate(textChannels + voiceChannels):
                 channel_name = channel["name"]
                 discord_id = channel["id"]
+                desired_kind = "voice" if channel.get("type") == 2 else "text"
                 
-                # 1. Already processed?
-                if discord_id in IDs["channels"]:
-                    step(i+1, total, f"{channel_name} ✓ already done")
+                # 1. Check Previous Mapping
+                revolt_id = IDs["channels"].get(discord_id)
+                if revolt_id and revolt_id in server_channel_ids and revolt_id not in used_revolt_ids:
+                    step(i+1, total, f"{channel_name} ✓ mapped reused")
+                    used_revolt_ids.add(revolt_id)
                     reused += 1
                     continue
+
+                # 2. Strict Match
+                key = (_norm_name(channel_name), desired_kind)
+                q = existing_by_key.get(key)
+                chosen = None
+                if q:
+                    while q and q[0].id in used_revolt_ids: q.popleft()
+                    if q: chosen = q.popleft()
                 
-                # 2. Exists on server?
-                if channel_name in existing_by_name:
-                    step(i+1, total, f"{channel_name} ✓ exists, reusing")
-                    rChannel = existing_by_name[channel_name]
-                    IDs["channels"][discord_id] = rChannel.id
-                    # If it's a real object, cache it
-                    if not isinstance(rChannel, RawChannel):
-                        cache["channels"][rChannel.id] = rChannel
+                # 3. Name Match
+                if chosen is None:
+                    qn = existing_by_name_queue.get(_norm_name(channel_name))
+                    if qn:
+                        while qn and qn[0].id in used_revolt_ids: qn.popleft()
+                        if qn: chosen = qn.popleft()
+
+                # 4. Fuzzy Match
+                if chosen is None:
+                    qs = existing_by_stripped_queue.get(_strip_name(channel_name))
+                    if qs:
+                        while qs and qs[0].id in used_revolt_ids: qs.popleft()
+                        if qs: chosen = qs.popleft()
+
+                if chosen:
+                    step(i+1, total, f"{channel_name} ✓ exists (fuzzy), reusing")
+                    IDs["channels"][discord_id] = chosen.id
+                    used_revolt_ids.add(chosen.id)
                     reused += 1
                     save_progress()
                     continue
                 
-                # 3. Create it
-                try:
-                    step(i+1, total, f"{channel_name} → creating...")
-                    rChannel = await server.create_channel(
-                        name = channel_name,
-                        description = channel.get("topic", ""), 
-                        nsfw = channel.get("nsfw", False),
-                        type = (
-                            pyvolt.ChannelType.voice 
-                            if channel["type"] == 2 else 
-                            pyvolt.ChannelType.text
+                if mode == "2":
+                    try:
+                        step(i+1, total, f"{channel_name} → creating...")
+                        rChannel = await server.create_channel(
+                            name = channel_name, 
+                            description = channel.get("topic", ""), 
+                            nsfw = channel.get("nsfw", False),
+                            type = (pyvolt.ChannelType.voice if channel["type"]==2 else pyvolt.ChannelType.text)
                         )
-                    )
-                    IDs["channels"][discord_id] = rChannel.id
-                    cache["channels"][rChannel.id] = rChannel
-                    existing_by_name[channel_name] = rChannel
-                    created += 1
-                    save_progress()
-                    
-                except pyvolt.HTTPException as e:
-                    if "TooManyChannels" in str(e):
-                        step(i+1, total, f"{channel_name} ⚠️ LIMIT REACHED")
+                        IDs["channels"][discord_id] = rChannel.id
+                        used_revolt_ids.add(rChannel.id)
+                        server_channel_ids.add(rChannel.id)
+                        created += 1
+                        save_progress()
+                    except pyvolt.HTTPException as e:
+                        if "TooManyChannels" in str(e):
+                            step(i+1, total, f"{channel_name} ⚠️ SERVER FULL (Limit Reached)")
+                            skipped += 1
+                        else:
+                            print(f" ❌ Error: {e}")
+                            skipped += 1
+                    except Exception as e:
+                        print(f" ❌ Error: {e}")
                         skipped += 1
-                    else:
-                        print(f"\n    ❌ Error creating {channel_name}: {e}")
-                        skipped += 1
-                except Exception as e:
-                    print(f"\n    ❌ Unexpected error: {e}")
-                    skipped += 1
 
             print(f"\n  📊 Summary: Created {created} | Reused {reused} | Skipped {skipped}")
 
             step(3, text="Setting up categories")
-
             category_list = []
-            for category in categories:
-                category_channels = [
-                    IDs["channels"][channel["id"]]
-                    for channel in textChannels + voiceChannels
-                    if channel.get("parent_id") == category["id"] and channel["id"] in IDs["channels"]
-                ]
-                
-                if category_channels:
-                    category_list.append(
-                        pyvolt.Category(
-                            id = str(category["id"]),
-                            title = category["name"],
-                            channels = category_channels
-                        )
-                    )
+            assigned_in_categories = set()
+
+            for i, category in enumerate(categories):
+                cat_channel_ids = []
+                for ch in textChannels + voiceChannels:
+                    if ch.get("parent_id") != category["id"]: continue
+                    r_id = IDs["channels"].get(ch["id"])
+                    if not r_id: continue
+                    if r_id not in server_channel_ids: continue
+                    if r_id in assigned_in_categories: continue
+                    
+                    assigned_in_categories.add(r_id)
+                    cat_channel_ids.append(r_id)
+
+                if cat_channel_ids:
+                    print(f"    [Staged {i+1}/{len(categories)}] {category['name'][:32]} ({len(cat_channel_ids)} channels)")
+                    category_list.append({
+                        "id": generate_ulid(),
+                        "title": category["name"][:32],
+                        "channels": cat_channel_ids
+                    })
 
             if category_list:
-                await server.edit(categories=category_list)
-                print(f"  ✅ Created {len(category_list)} categories")
+                print(f"  📦 Sending {len(category_list)} categories via Direct API...")
+                try:
+                    api_headers = {"x-bot-token": bot_token, "Content-Type": "application/json"}
+                    payload = {"categories": category_list}
+                    resp = requests.patch(
+                        f"https://api.revolt.chat/servers/{target_server_id}",
+                        headers=api_headers, json=payload, timeout=30
+                    )
+                    if resp.status_code == 200:
+                        print("  ✅ Categories updated successfully!")
+                    else:
+                        print(f"  ❌ Failed: {resp.status_code} - {resp.text}")
+                except Exception as e:
+                    print(f"  ❌ Exception: {e}")
 
-            step(4, text="Creating/updating roles")
-            
-            # FIX: Find the @everyone role ID safely
+            step(4, text="Creating roles")
             template_everyone_id = None
             for r in template["roles"]:
                 if r["name"] == "@everyone":
-                    template_everyone_id = r["id"]
-                    break
-            if template_everyone_id is None and "id" in template:
-                template_everyone_id = template["id"]
+                    template_everyone_id = r["id"]; break
+            if template_everyone_id is None and "id" in template: template_everyone_id = template["id"]
 
-            try:
-                existing_roles = await server.fetch_roles()
-            except:
-                existing_roles = []
-            
-            existing_roles_by_name = {role.name: role for role in existing_roles}
+            try: existing_roles = await server.fetch_roles()
+            except: existing_roles = []
+            existing_roles_by_name = {r.name: r for r in existing_roles}
             
             total_roles = len(template["roles"])
             for i, role in enumerate(template["roles"]):
                 role_name = role["name"]
-                discord_id = role["id"]
-                step(i+1, total_roles, role_name)
                 
-                if discord_id == template_everyone_id:
-                    await server.set_default_permissions(
-                        convert_permission(role["permissions"])
-                    )
+                if role["id"] == template_everyone_id:
+                    print(f"    [{i+1}/{total_roles}] @everyone -> Updating perms")
+                    await server.set_default_permissions(convert_permission(role["permissions"]))
                     continue
+
+                rRole = None
+                status = "Creating"
+
+                # Check if we should reuse
+                if role["id"] in IDs["roles"]:
+                    rRole = next((r for r in existing_roles if r.id == IDs["roles"][role["id"]]), None)
+                    if not rRole and role["name"] in existing_roles_by_name:
+                        rRole = existing_roles_by_name[role["name"]]
+                    if rRole: status = "Reusing"
+                elif role["name"] in existing_roles_by_name:
+                    rRole = existing_roles_by_name[role["name"]]
+                    status = "Reusing"
                 
-                if discord_id in IDs["roles"]:
-                    rRole = next((r for r in existing_roles if r.id == IDs["roles"][discord_id]), None)
-                    if not rRole and role_name in existing_roles_by_name:
-                        rRole = existing_roles_by_name[role_name]
-                elif role_name in existing_roles_by_name:
-                    rRole = existing_roles_by_name[role_name]
-                else:
-                    rRole = await server.create_role(name=role_name, rank=role.get("position", 1))
+                print(f"    [{i+1}/{total_roles}] {role_name} -> {status}")
+
+                if not rRole:
+                    rRole = await server.create_role(name=role["name"], rank=role.get("position", 1))
                 
                 if rRole:
-                    IDs["roles"][discord_id] = rRole.id
+                    IDs["roles"][role["id"]] = rRole.id
                     cache["roles"][rRole.id] = rRole
-                    
-                    color_hex = "#" + hex(role.get("color", 0))[2:].zfill(6)
-                    await rRole.edit(color=color_hex, hoist=role.get("hoist", False))
-                    await server.set_role_permissions(
-                        rRole,
-                        allow=convert_permission(role["permissions"]),
-                        deny=pyvolt.Permissions(0)
-                    )
+                    color = "#" + hex(role.get("color", 0))[2:].zfill(6)
+                    await rRole.edit(color=color, hoist=role.get("hoist", False))
+                    await server.set_role_permissions(rRole, allow=convert_permission(role["permissions"]), deny=pyvolt.Permissions(0))
                     save_progress()
 
-            step(5, text="Setting channel permissions")
-
-            channels_with_perms = [
-                ch for ch in textChannels + voiceChannels
-                if ch.get("permission_overwrites") and ch["id"] in IDs["channels"]
-            ]
-            
-            for i, channel in enumerate(channels_with_perms):
-                step(i+1, len(channels_with_perms), channel["name"])
-                revolt_id = IDs["channels"][channel["id"]]
-                
-                # We need a REAL object to set permissions
-                rChannel = cache["channels"].get(revolt_id)
-                
-                # If it's not in cache or is a RawChannel, we must fetch the real object
+            step(5, text="Permissions")
+            channels_with_perms = [ch for ch in textChannels + voiceChannels if ch.get("permission_overwrites") and ch["id"] in IDs["channels"]]
+            for i, ch in enumerate(channels_with_perms):
+                print(f"    [{i+1}/{len(channels_with_perms)}] {ch['name']} -> Setting overrides")
+                rID = IDs["channels"][ch["id"]]
+                rChannel = cache["channels"].get(rID)
                 if not rChannel or isinstance(rChannel, RawChannel):
-                    try:
-                        rChannel = await client.fetch_channel(revolt_id)
-                        cache["channels"][revolt_id] = rChannel
-                    except:
-                        print(f"    ⚠️ Could not fetch channel {channel['name']} for permissions")
-                        continue
-
-                for overwrite in channel["permission_overwrites"]:
-                    ow = {
-                        "allow": convert_permission(overwrite.get("allow", 0)),
-                        "deny": convert_permission(overwrite.get("deny", 0)),
-                    }
-
-                    if overwrite["id"] == template_everyone_id:
-                        await rChannel.set_default_permissions(pyvolt.PermissionOverride(**ow))
-                    elif overwrite["id"] in IDs["roles"]:
-                        await rChannel.set_role_permissions(d2r("roles", overwrite["id"]), **ow)
+                    try: rChannel = await client.fetch_channel(rID); cache["channels"][rID] = rChannel
+                    except: continue
+                
+                for ow in ch["permission_overwrites"]:
+                    p = {"allow": convert_permission(ow.get("allow",0)), "deny": convert_permission(ow.get("deny",0))}
+                    if ow["id"] == template_everyone_id: await rChannel.set_default_permissions(pyvolt.PermissionOverride(**p))
+                    elif ow["id"] in IDs["roles"]: await rChannel.set_role_permissions(d2r("roles", ow["id"]), **p)
             
             print("\n✅ Import complete!")
             if skipped > 0:
-                print(f"\n⚠️  {skipped} channels skipped (200 channel limit reached)")
+                print(f"\n⚠️  {skipped} channels skipped because the server is full (200 limit).")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import time
 import random
 import re
 import os
+import sys
 from collections import defaultdict, deque
 from pathlib import Path
 
@@ -44,25 +45,65 @@ class RawChannel:
     def __repr__(self):
         return f"<RawChannel id={self.id} name={self.name}>"
 
+class RawRole:
+    def __init__(self, id, data):
+        self.id = id
+        self.name = data.get("name", "Unknown")
+        self.rank = data.get("rank", 0)
+        self.color = data.get("colour", None)
+        self.hoist = data.get("hoist", False)
+        self._raw = data
+    def __repr__(self):
+        return f"<RawRole id={self.id} name={self.name}>"
+
+def log(text, end="\n"):
+    """Instant logging helper that flushes stdout."""
+    print(text, end=end)
+    sys.stdout.flush()
+
 def revolt_api_json(method: str, url: str, headers: dict, payload: dict | None = None, params: dict | None = None, timeout: int = 30):
-    """HTTP helper with retry + 429 handling + params support."""
+    """HTTP helper with SMART retry + 429 handling."""
     for attempt in range(6):
         try:
             resp = requests.request(method, url, headers=headers, json=payload, params=params, timeout=timeout)
+            
+            # Rate Limit Handling
             if resp.status_code == 429:
+                retry_after = 1.0 # Default fallback
+                
+                # Check Standard Header (Seconds)
+                if "Retry-After" in resp.headers:
+                    try: retry_after = float(resp.headers["Retry-After"])
+                    except: pass
+                
+                # Check Revolt specific JSON body (Usually Milliseconds)
                 try:
                     data = resp.json()
-                    retry_after = float(data.get("retry_after", 2.0))
+                    json_retry = data.get("retry_after")
+                    if json_retry:
+                        val = float(json_retry)
+                        # Heuristic: If value is huge (>1000), it's milliseconds. 
+                        if val > 500: 
+                            val = val / 1000.0
+                        
+                        # Take the larger of the two to be safe
+                        retry_after = max(retry_after, val)
                 except:
-                    retry_after = 2.0
-                print(f"    ⏳ Rate limit hit, waiting {retry_after}s...")
-                time.sleep(retry_after + 0.5)
+                    pass
+                
+                log(f"    ⏳ Rate limit hit, waiting {retry_after:.2f}s...")
+                time.sleep(retry_after + 0.1) # Tiny buffer
                 continue
+            
+            # Server Error Handling
             if resp.status_code >= 500 and attempt < 5:
                 time.sleep(1)
                 continue
+            
+            # Client Error Handling
             if resp.status_code >= 400:
                 return {"error": resp.text, "status": resp.status_code}
+            
             return resp.json()
         except Exception as e:
             if attempt == 5:
@@ -70,11 +111,9 @@ def revolt_api_json(method: str, url: str, headers: dict, payload: dict | None =
             time.sleep(1)
 
 def _norm_name(name: str) -> str:
-    """Basic normalization (lowercase, stripped)."""
     return (name or "").casefold().strip()
 
 def _strip_name(name: str) -> str:
-    """Aggressive normalization: removes emojis/symbols to match 'Factorio' with '⚙️Factorio⚙️'."""
     return re.sub(r'[\W_]+', '', name).lower()
 
 def _revolt_channel_kind(ch) -> str:
@@ -94,9 +133,9 @@ def _revolt_channel_kind(ch) -> str:
     return "unknown"
 
 def build_existing_queues(current_channels):
-    by_key = defaultdict(deque)      # (norm_name, kind)
-    by_name = defaultdict(deque)     # norm_name
-    by_stripped = defaultdict(deque) # stripped_name (fuzzy match)
+    by_key = defaultdict(deque)
+    by_name = defaultdict(deque)
+    by_stripped = defaultdict(deque)
     
     for ch in current_channels:
         name_raw = getattr(ch, "name", "")
@@ -110,9 +149,12 @@ def build_existing_queues(current_channels):
         
     return by_key, by_name, by_stripped
 
-def save_progress():
-    with open(PROGRESS_FILE, 'w') as f:
-        json.dump(IDs, f, indent=2)
+def save_progress(force=False):
+    if not hasattr(save_progress, "counter"): save_progress.counter = 0
+    save_progress.counter += 1
+    if force or save_progress.counter % 10 == 0:
+        with open(PROGRESS_FILE, 'w') as f:
+            json.dump(IDs, f, indent=2)
     
 def load_progress():
     if Path(PROGRESS_FILE).exists():
@@ -127,7 +169,7 @@ def d2r(type, id):
     return cache[type][IDs[type][id]]
 
 def step(current, total=None, text="Something is wrong"):
-    print(("\t" if total else ""), "[", current, "/", total or TEMPLATE_IMPORT_STEPS, "] ", text, sep='')
+    log(("\t" if total else "") + f"[{current}/{total or TEMPLATE_IMPORT_STEPS}] {text}")
 
 def convert_permission(permissions: int):
     d2r_map = {43:4, 40:8, 29:24, 28:3, 26:10, 27:11, 0:25, 1:6, 2:7, 4:0, 5:1, 6:29,10:20,11:22,13:23,14:26,15:27,16:21,20:30,21:31,23:34,22:33,24:35}
@@ -136,6 +178,143 @@ def convert_permission(permissions: int):
     for i in d2r_map:
         if permissions & (1 << i): out |= 1 << d2r_map[i]
     return pyvolt.Permissions(out)
+
+# ═══════════════════════════════════════════════════════
+#  CORE LOGIC: PROCESS ROLES (Responsive)
+# ═══════════════════════════════════════════════════════
+async def process_roles_logic(server, template, target_server_id, bot_token):
+    log("    🔍 Fetching roles via Direct API...")
+    raw_roles = []
+    try:
+        server_data = revolt_api_json("GET", f"https://api.revolt.chat/servers/{target_server_id}", headers={"x-bot-token": bot_token})
+        if isinstance(server_data, dict) and "roles" in server_data:
+            for r_id, r_data in server_data["roles"].items():
+                raw_roles.append(RawRole(r_id, r_data))
+        else:
+            lib_roles = await server.fetch_roles()
+            raw_roles = [RawRole(r.id, {"name": r.name, "rank": r.rank, "colour": r.color, "hoist": r.hoist}) for r in lib_roles]
+    except Exception as e:
+        log(f"    ❌ Failed: {e}")
+        return
+
+    log(f"    ✅ Found {len(raw_roles)} existing roles.")
+
+    # --- 1. DUPLICATE CLEANUP ---
+    log("    🧹 Analyzing duplicates...")
+    roles_by_name = defaultdict(list)
+    for r in raw_roles:
+        roles_by_name[_norm_name(r.name)].append(r)
+    
+    ids_to_delete = []
+    cleaned_roles = []
+    
+    for norm_name, r_list in roles_by_name.items():
+        if len(r_list) > 1:
+            keep = r_list[0]
+            cleaned_roles.append(keep)
+            for bad in r_list[1:]:
+                if bad.id == target_server_id: continue 
+                ids_to_delete.append((bad.id, bad.name))
+        else:
+            cleaned_roles.append(r_list[0])
+
+    if ids_to_delete:
+        log(f"    🗑️  Deleting {len(ids_to_delete)} duplicate roles...")
+        
+        for i, (rid, rname) in enumerate(ids_to_delete):
+            revolt_api_json("DELETE", f"https://api.revolt.chat/servers/{target_server_id}/roles/{rid}", headers={"x-bot-token": bot_token})
+            
+            # RESPONSIVE LOGGING: Overwrite current line
+            sys.stdout.write(f"\r       Deleted {i+1}/{len(ids_to_delete)} duplicates... ({rname})          ")
+            sys.stdout.flush()
+            
+        log(f"\n       ✅ Cleanup finished.        ")
+
+    existing_roles_map = {_norm_name(r.name): r for r in cleaned_roles}
+    
+    # --- 2. CREATE / REUSE ---
+    template_everyone_id = None
+    for r in template["roles"]:
+        if r["name"] == "@everyone": template_everyone_id = r["id"]; break
+    if template_everyone_id is None: template_everyone_id = template.get("id")
+
+    total_roles = len(template["roles"])
+    
+    log("    ⚙️  Syncing roles...")
+    for i, role in enumerate(template["roles"]):
+        role_name = role["name"]
+        norm_input_name = _norm_name(role_name)
+        
+        if role["id"] == template_everyone_id:
+            log(f"    [{i+1}/{total_roles}] @everyone -> Updating perms")
+            await server.set_default_permissions(convert_permission(role["permissions"]))
+            continue
+
+        rRole = None
+        status = "Creating"
+
+        if role["id"] in IDs["roles"]:
+            rid = IDs["roles"][role["id"]]
+            found = next((r for r in cleaned_roles if r.id == rid), None)
+            if found: 
+                rRole = found
+                status = "Reusing"
+        
+        if not rRole and norm_input_name in existing_roles_map:
+            rRole = existing_roles_map[norm_input_name]
+            status = "Reusing"
+
+        if status == "Creating" or i % 10 == 0:
+            log(f"    [{i+1}/{total_roles}] {role_name} -> {status}")
+
+        if not rRole:
+            try:
+                payload = {
+                    "name": role["name"],
+                    "rank": role.get("position", 0)
+                }
+                resp = revolt_api_json("POST", f"https://api.revolt.chat/servers/{target_server_id}/roles", headers={"x-bot-token": bot_token}, payload=payload)
+                
+                if isinstance(resp, dict) and "id" in resp:
+                    new_id = resp["id"]
+                    rRole = RawRole(new_id, {"name": role["name"], "rank": 0}) 
+                    new_raw = rRole
+                    cleaned_roles.append(new_raw)
+                    existing_roles_map[_norm_name(role["name"])] = new_raw
+                else:
+                    log(f"      ❌ API Error creating role: {resp}")
+                    continue
+            except Exception as e:
+                log(f"      ❌ Create Failed: {e}")
+                continue
+        else:
+            # Optimization: Skip if colors match
+            target_color = "#" + hex(role.get("color", 0))[2:].zfill(6)
+            current_color = getattr(rRole, "color", None)
+            
+            if current_color and current_color.lower() == target_color.lower():
+                IDs["roles"][role["id"]] = rRole.id
+                cache["roles"][rRole.id] = rRole
+                continue
+
+            if isinstance(rRole, RawRole):
+                try: rRole = await server.fetch_role(rRole.id)
+                except: continue
+
+        if rRole:
+            IDs["roles"][role["id"]] = rRole.id
+            cache["roles"][rRole.id] = rRole
+            
+            try:
+                color = "#" + hex(role.get("color", 0))[2:].zfill(6)
+                await rRole.edit(color=color, hoist=role.get("hoist", False))
+                await server.set_role_permissions(rRole, allow=convert_permission(role["permissions"]), deny=pyvolt.Permissions(0))
+            except: pass
+            
+            save_progress()
+
+    save_progress(force=True)
+
 
 async def main():
     has_progress = load_progress()
@@ -149,315 +328,181 @@ async def main():
             IDs["channels"].clear()
             print("🔄 Starting fresh...\n")
     
-    # --- 1. Get Template URL ---
     template_url = os.getenv("DISCORD_TEMPLATE_URL")
     template = None
-    
     while not template:
-        if not template_url:
-            template_url = input("Template URL: ")
-            
-        template_code = template_url.split("/")[-1]
-        
-        if template_code == "":
-            try:
-                template = json.load(open("demo_template.json"))["serialized_source_guild"]
-                break
-            except:
-                print("❌ demo_template.json not found.")
-                template_url = None
-                continue
-
+        if not template_url: template_url = input("Template URL: ")
+        code = template_url.split("/")[-1]
+        if not code:
+            try: template = json.load(open("demo_template.json"))["serialized_source_guild"]; break
+            except: print("❌ demo_template.json not found."); template_url=None; continue
         try:
             headers = {"User-Agent": "Mozilla/5.0", "Accept": "application/json"}
-            resp = requests.get(f"https://discord.com/api/v9/guilds/templates/{template_code}", headers=headers)
-            if resp.status_code != 200:
-                print(f"❌ API Error: {resp.status_code}")
-                template_url = None
-                continue
+            resp = requests.get(f"https://discord.com/api/v9/guilds/templates/{code}", headers=headers)
+            if resp.status_code != 200: print(f"❌ API Error: {resp.status_code}"); template_url=None; continue
             template = resp.json()["serialized_source_guild"]
-        except Exception as error: 
-            print(f"❌ Error: {error}")
-            template_url = None
-            template = None
+        except: template_url=None
 
-    print(f"""
-    Ready to import template: "{template['name']}"
-    {len(template['channels'])} channels and {len(template['roles'])} roles will be imported.
-    """)
+    print(f"Ready to import: {template['name']}")
     
-    # --- 2. Get Credentials ---
-    target_server_id = os.getenv("REVOLT_SERVER_ID")
-    if not target_server_id:
-        target_server_id = input("Target Revolt Server ID: ")
-        
-    bot_token = os.getenv("REVOLT_BOT_TOKEN")
-    if not bot_token:
-        bot_token = input("Revolt Bot Token: ")
+    target_server_id = os.getenv("REVOLT_SERVER_ID") or input("Target Revolt Server ID: ")
+    bot_token = os.getenv("REVOLT_BOT_TOKEN") or input("Revolt Bot Token: ")
     
     async with pyvolt.Client(token=bot_token, bot=True) as client:
         try:
             print(f"Fetching server {target_server_id}...")
             server = await client.fetch_server(target_server_id)
-            print(f"✅ Connected to server: {server.name}")
-        except Exception as error:
-            print(f"❌ Error fetching server: {error}")
-            return
+            print(f"✅ Connected to: {server.name}")
+        except: return
 
-        print("\n🔍 Scanning server for existing channels...")
+        print("\n🔍 Scanning server...")
         current_channels = []
-        
-        # Optimized Bulk Fetch
         try:
-            api_headers = {"x-bot-token": bot_token}
-            server_data = revolt_api_json(
-                "GET", 
-                f"https://api.revolt.chat/servers/{target_server_id}", 
-                headers=api_headers,
-                params={"include_channels": "true"}
-            )
-            
-            if isinstance(server_data, dict):
-                if "channels" in server_data and isinstance(server_data["channels"], list):
-                    raw_list = server_data["channels"]
-                    if len(raw_list) > 0 and isinstance(raw_list[0], dict):
-                        for ch_data in raw_list:
-                            current_channels.append(RawChannel(ch_data))
-                    elif len(raw_list) > 0 and isinstance(raw_list[0], str):
-                        print(f"   ℹ️ API returned IDs only. Fetching {len(raw_list)} channels...")
-                        for cid in raw_list:
-                            ch_data = revolt_api_json("GET", f"https://api.revolt.chat/channels/{cid}", headers=api_headers)
-                            if isinstance(ch_data, dict) and ch_data.get("_id"):
-                                current_channels.append(RawChannel(ch_data))
-        except Exception as e:
-            print(f"   ❌ API error: {e}")
-
-        # Fallback to library cache
-        if not current_channels:
+            headers = {"x-bot-token": bot_token}
+            data = revolt_api_json("GET", f"https://api.revolt.chat/servers/{target_server_id}", headers=headers, params={"include_channels": "true"})
+            if isinstance(data, dict) and "channels" in data:
+                for d in data["channels"]:
+                    if isinstance(d, dict): current_channels.append(RawChannel(d))
+        except: pass
+        if not current_channels: 
              if hasattr(server, 'channels'): current_channels = list(server.channels)
-             elif hasattr(server, '_channels'): current_channels = list(server._channels.values())
 
-        print(f"✅ Found {len(current_channels)} existing channels on Revolt server")
-        if len(current_channels) >= 190:
-            print("⚠️  WARNING: Server is nearing the 200 channel limit. Fuzzy matching will try to reuse existing channels to avoid errors.")
-        
+        print(f"✅ Found {len(current_channels)} channels")
         server_channel_ids = {ch.id for ch in current_channels}
         existing_by_key, existing_by_name_queue, existing_by_stripped_queue = build_existing_queues(current_channels)
         
-        print("\n╔════════════════════════════════════════════════════════╗")
-        print("║                    IMPORT MODES                        ║")
-        print("╚════════════════════════════════════════════════════════╝")
-        print("1. 🚀 CATEGORIES ONLY - Fast! Just organize existing channels")
-        print("2. 🔄 SMART MODE     - Reuse existing channels, create missing ones")
-        print("3. 🗑️  CLEAN SLATE   - Delete everything and recreate from template")
-        mode = input("\nChoose mode (1/2/3): ").strip()
+        print("\n1. 🚀 CATEGORIES ONLY")
+        print("2. 🔄 SMART MODE (Recommended)")
+        print("3. 🗑️  CLEAN SLATE")
+        print("4. 🎭 ROLES ONLY")
+        mode = input("Choose mode (1-4): ").strip()
 
         channels = template["channels"]
         textChannels = list(filter(lambda channel: channel["type"] not in [2, 4], channels))
         voiceChannels = list(filter(lambda channel: channel["type"] == 2, channels))
         categories = list(filter(lambda channel: channel["type"] == 4, channels))
 
+        if mode == "4":
+            step(1, 1, "Processing Roles")
+            await process_roles_logic(server, template, target_server_id, bot_token)
+            print("\n✅ Role Sync Complete!")
+            return
+
         if mode == "3":
             step(1, text="Deleting channels")
             for ch in current_channels:
                 try:
-                    if isinstance(ch, RawChannel):
-                        requests.delete(f"https://api.revolt.chat/channels/{ch.id}", headers={"x-bot-token": bot_token})
-                    else:
-                        await ch.close()
+                    if isinstance(ch, RawChannel): requests.delete(f"https://api.revolt.chat/channels/{ch.id}", headers={"x-bot-token": bot_token})
+                    else: await ch.close()
                 except: pass
             current_channels = []
-            existing_by_key, existing_by_name_queue, existing_by_stripped_queue = defaultdict(deque), defaultdict(deque), defaultdict(deque)
+            existing_by_key = defaultdict(deque); existing_by_name_queue = defaultdict(deque); existing_by_stripped_queue = defaultdict(deque)
             server_channel_ids = set()
-            IDs["channels"].clear()
-            IDs["roles"].clear()
-            save_progress()
+            IDs["channels"].clear(); IDs["roles"].clear()
+            save_progress(force=True)
             mode = "2"
 
         if mode == "1" or mode == "2":
-            mode_name = "SMART MODE" if mode == "2" else "CATEGORIES ONLY"
-            print(f"\n🔄 {mode_name}\n")
-            
             step(2, text="Processing channels")
             total = len(textChannels) + len(voiceChannels)
-            created = 0
-            reused = 0
-            skipped = 0
+            created, reused, skipped = 0, 0, 0
             used_revolt_ids = set()
             
             for i, channel in enumerate(textChannels + voiceChannels):
-                channel_name = channel["name"]
-                discord_id = channel["id"]
-                desired_kind = "voice" if channel.get("type") == 2 else "text"
+                cname, cid = channel["name"], channel["id"]
+                kind = "voice" if channel.get("type")==2 else "text"
                 
-                # 1. Check Previous Mapping
-                revolt_id = IDs["channels"].get(discord_id)
+                revolt_id = IDs["channels"].get(cid)
                 if revolt_id and revolt_id in server_channel_ids and revolt_id not in used_revolt_ids:
-                    step(i+1, total, f"{channel_name} ✓ mapped reused")
-                    used_revolt_ids.add(revolt_id)
-                    reused += 1
-                    continue
+                    used_revolt_ids.add(revolt_id); reused += 1; continue
 
-                # 2. Strict Match
-                key = (_norm_name(channel_name), desired_kind)
-                q = existing_by_key.get(key)
+                key = (_norm_name(cname), kind)
                 chosen = None
-                if q:
+                
+                q = existing_by_key.get(key)
+                if q: 
                     while q and q[0].id in used_revolt_ids: q.popleft()
                     if q: chosen = q.popleft()
                 
-                # 3. Name Match
-                if chosen is None:
-                    qn = existing_by_name_queue.get(_norm_name(channel_name))
+                if not chosen:
+                    qn = existing_by_name_queue.get(_norm_name(cname))
                     if qn:
                         while qn and qn[0].id in used_revolt_ids: qn.popleft()
                         if qn: chosen = qn.popleft()
-
-                # 4. Fuzzy Match
-                if chosen is None:
-                    qs = existing_by_stripped_queue.get(_strip_name(channel_name))
+                
+                if not chosen:
+                    qs = existing_by_stripped_queue.get(_strip_name(cname))
                     if qs:
                         while qs and qs[0].id in used_revolt_ids: qs.popleft()
                         if qs: chosen = qs.popleft()
 
                 if chosen:
-                    step(i+1, total, f"{channel_name} ✓ exists (fuzzy), reusing")
-                    IDs["channels"][discord_id] = chosen.id
-                    used_revolt_ids.add(chosen.id)
-                    reused += 1
-                    save_progress()
+                    if i%5==0: step(i+1, total, f"{cname} ✓ reused")
+                    IDs["channels"][cid] = chosen.id; used_revolt_ids.add(chosen.id); reused += 1; save_progress()
                     continue
                 
                 if mode == "2":
                     try:
-                        step(i+1, total, f"{channel_name} → creating...")
+                        step(i+1, total, f"{cname} → creating...")
                         rChannel = await server.create_channel(
-                            name = channel_name, 
-                            description = channel.get("topic", ""), 
-                            nsfw = channel.get("nsfw", False),
-                            type = (pyvolt.ChannelType.voice if channel["type"]==2 else pyvolt.ChannelType.text)
+                            name=cname, description=channel.get("topic",""), nsfw=channel.get("nsfw",False),
+                            type=(pyvolt.ChannelType.voice if kind=="voice" else pyvolt.ChannelType.text)
                         )
-                        IDs["channels"][discord_id] = rChannel.id
-                        used_revolt_ids.add(rChannel.id)
-                        server_channel_ids.add(rChannel.id)
-                        created += 1
-                        save_progress()
+                        IDs["channels"][cid] = rChannel.id; used_revolt_ids.add(rChannel.id); server_channel_ids.add(rChannel.id)
+                        created += 1; save_progress()
                     except pyvolt.HTTPException as e:
-                        if "TooManyChannels" in str(e):
-                            step(i+1, total, f"{channel_name} ⚠️ SERVER FULL (Limit Reached)")
-                            skipped += 1
-                        else:
-                            print(f" ❌ Error: {e}")
-                            skipped += 1
-                    except Exception as e:
-                        print(f" ❌ Error: {e}")
-                        skipped += 1
+                        if "TooManyChannels" in str(e): step(i+1, total, f"{cname} ⚠️ SERVER FULL"); skipped += 1
+                        else: log(f" ❌ Error: {e}"); skipped += 1
+                    except: skipped += 1
 
+            save_progress(force=True)
             print(f"\n  📊 Summary: Created {created} | Reused {reused} | Skipped {skipped}")
 
-            step(3, text="Setting up categories")
+            step(3, text="Categories")
             category_list = []
-            assigned_in_categories = set()
-
-            for i, category in enumerate(categories):
-                cat_channel_ids = []
+            assigned = set()
+            for i, cat in enumerate(categories):
+                ch_ids = []
                 for ch in textChannels + voiceChannels:
-                    if ch.get("parent_id") != category["id"]: continue
-                    r_id = IDs["channels"].get(ch["id"])
-                    if not r_id: continue
-                    if r_id not in server_channel_ids: continue
-                    if r_id in assigned_in_categories: continue
-                    
-                    assigned_in_categories.add(r_id)
-                    cat_channel_ids.append(r_id)
-
-                if cat_channel_ids:
-                    print(f"    [Staged {i+1}/{len(categories)}] {category['name'][:32]} ({len(cat_channel_ids)} channels)")
-                    category_list.append({
-                        "id": generate_ulid(),
-                        "title": category["name"][:32],
-                        "channels": cat_channel_ids
-                    })
+                    if ch.get("parent_id") != cat["id"]: continue
+                    rid = IDs["channels"].get(ch["id"])
+                    if rid and rid in server_channel_ids and rid not in assigned:
+                        assigned.add(rid); ch_ids.append(rid)
+                if ch_ids:
+                    log(f"    [Staged {i+1}/{len(categories)}] {cat['name'][:32]}")
+                    category_list.append({"id": generate_ulid(), "title": cat["name"][:32], "channels": ch_ids})
 
             if category_list:
-                print(f"  📦 Sending {len(category_list)} categories via Direct API...")
-                try:
-                    api_headers = {"x-bot-token": bot_token, "Content-Type": "application/json"}
-                    payload = {"categories": category_list}
-                    resp = requests.patch(
-                        f"https://api.revolt.chat/servers/{target_server_id}",
-                        headers=api_headers, json=payload, timeout=30
-                    )
-                    if resp.status_code == 200:
-                        print("  ✅ Categories updated successfully!")
-                    else:
-                        print(f"  ❌ Failed: {resp.status_code} - {resp.text}")
-                except Exception as e:
-                    print(f"  ❌ Exception: {e}")
+                log(f"  📦 Sending categories...")
+                try: requests.patch(f"https://api.revolt.chat/servers/{target_server_id}", headers={"x-bot-token": bot_token}, json={"categories": category_list})
+                except: pass
 
-            step(4, text="Creating roles")
-            template_everyone_id = None
-            for r in template["roles"]:
-                if r["name"] == "@everyone":
-                    template_everyone_id = r["id"]; break
-            if template_everyone_id is None and "id" in template: template_everyone_id = template["id"]
-
-            try: existing_roles = await server.fetch_roles()
-            except: existing_roles = []
-            existing_roles_by_name = {r.name: r for r in existing_roles}
-            
-            total_roles = len(template["roles"])
-            for i, role in enumerate(template["roles"]):
-                role_name = role["name"]
-                
-                if role["id"] == template_everyone_id:
-                    print(f"    [{i+1}/{total_roles}] @everyone -> Updating perms")
-                    await server.set_default_permissions(convert_permission(role["permissions"]))
-                    continue
-
-                rRole = None
-                status = "Creating"
-
-                if role["id"] in IDs["roles"]:
-                    rRole = next((r for r in existing_roles if r.id == IDs["roles"][role["id"]]), None)
-                    if not rRole and role["name"] in existing_roles_by_name:
-                        rRole = existing_roles_by_name[role["name"]]
-                    if rRole: status = "Reusing"
-                elif role["name"] in existing_roles_by_name:
-                    rRole = existing_roles_by_name[role["name"]]
-                    status = "Reusing"
-                
-                print(f"    [{i+1}/{total_roles}] {role_name} -> {status}")
-
-                if not rRole:
-                    rRole = await server.create_role(name=role["name"], rank=role.get("position", 1))
-                
-                if rRole:
-                    IDs["roles"][role["id"]] = rRole.id
-                    cache["roles"][rRole.id] = rRole
-                    color = "#" + hex(role.get("color", 0))[2:].zfill(6)
-                    await rRole.edit(color=color, hoist=role.get("hoist", False))
-                    await server.set_role_permissions(rRole, allow=convert_permission(role["permissions"]), deny=pyvolt.Permissions(0))
-                    save_progress()
+            step(4, text="Processing roles")
+            await process_roles_logic(server, template, target_server_id, bot_token)
 
             step(5, text="Permissions")
             channels_with_perms = [ch for ch in textChannels + voiceChannels if ch.get("permission_overwrites") and ch["id"] in IDs["channels"]]
             for i, ch in enumerate(channels_with_perms):
-                print(f"    [{i+1}/{len(channels_with_perms)}] {ch['name']} -> Setting overrides")
+                if i % 10 == 0: log(f"    Setting perms for batch {i}...", end="\r")
                 rID = IDs["channels"][ch["id"]]
                 rChannel = cache["channels"].get(rID)
                 if not rChannel or isinstance(rChannel, RawChannel):
                     try: rChannel = await client.fetch_channel(rID); cache["channels"][rID] = rChannel
                     except: continue
                 
+                template_everyone_id = None
+                for r in template["roles"]:
+                    if r["name"] == "@everyone": template_everyone_id = r["id"]; break
+                if not template_everyone_id: template_everyone_id = template.get("id")
+
                 for ow in ch["permission_overwrites"]:
                     p = {"allow": convert_permission(ow.get("allow",0)), "deny": convert_permission(ow.get("deny",0))}
                     if ow["id"] == template_everyone_id: await rChannel.set_default_permissions(pyvolt.PermissionOverride(**p))
                     elif ow["id"] in IDs["roles"]: await rChannel.set_role_permissions(d2r("roles", ow["id"]), **p)
-            
+                time.sleep(0.1) # Fast Pacing
+
             print("\n✅ Import complete!")
-            if skipped > 0:
-                print(f"\n⚠️  {skipped} channels skipped because the server is full (200 limit).")
+            if skipped > 0: print(f"\n⚠️  {skipped} channels skipped (200 limit).")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests
+stoat
+python-dotenv


### PR DESCRIPTION
Refactor main.py to make Discord->Revolt template imports much more robust. Adds import_progress.json persistence (save/load), a RawChannel fallback for missing library objects, and revolt_api_json helper with retries and 429 handling. Implements duplicate-safe channel lookup queues, safer channel fetching (library + direct API fallback), and three import modes (categories-only, smart reuse, clean-slate). Reworks permission mapping and conversion, uses async client context, improves error messages and user prompts, and persists ID mappings as channels/roles are processed. Also updates .gitignore to exclude all .json files.